### PR TITLE
Add basic Node test for time utils

### DIFF
--- a/01_Projects/JTool - attempt/src/utils/time.js
+++ b/01_Projects/JTool - attempt/src/utils/time.js
@@ -1,0 +1,13 @@
+function formatMillisToHMS(ms) {
+  if (typeof ms !== 'number' || isNaN(ms)) return '00:00:00';
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  return (
+    (hours < 10 ? '0' + hours : hours) + ':' +
+    (minutes < 10 ? '0' + minutes : minutes) + ':' +
+    (seconds < 10 ? '0' + seconds : seconds)
+  );
+}
+module.exports = { formatMillisToHMS };

--- a/test/timeUtils.test.js
+++ b/test/timeUtils.test.js
@@ -1,0 +1,19 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { formatMillisToHMS } = require('../01_Projects/JTool - attempt/src/utils/time');
+
+test('formatMillisToHMS formats 0 correctly', () => {
+  assert.strictEqual(formatMillisToHMS(0), '00:00:00');
+});
+
+test('formatMillisToHMS formats one second', () => {
+  assert.strictEqual(formatMillisToHMS(1000), '00:00:01');
+});
+
+test('formatMillisToHMS formats minutes and hours', () => {
+  assert.strictEqual(formatMillisToHMS(3661000), '01:01:01');
+});
+
+test('formatMillisToHMS handles invalid input', () => {
+  assert.strictEqual(formatMillisToHMS('abc'), '00:00:00');
+});


### PR DESCRIPTION
## Summary
- add `formatMillisToHMS` utility
- create Node.js test using built-in `test` runner

## Testing
- `node --test test/timeUtils.test.js`
- `pytest -q` *(fails: command not found)*