### PR TITLE
Add configurable settings modal

### DIFF
--- a/01_Projects/JTool - attempt/src/popup/bg-animation.js
+++ b/01_Projects/JTool - attempt/src/popup/bg-animation.js
@@ -1,9 +1,17 @@
 (function () {
-  const canvas = document.getElementById("bgCanvas");
-  if (!canvas) {
-    console.warn("Background canvas element not found.");
-    return;
-  }
+  const browserAPI = chrome || browser;
+  browserAPI.storage.local.get({ settings: { showAnimation: true } }, (data) => {
+    if (!data.settings?.showAnimation) {
+      const canvas = document.getElementById("bgCanvas");
+      if (canvas) canvas.remove();
+      return;
+    }
+
+    const canvas = document.getElementById("bgCanvas");
+    if (!canvas) {
+      console.warn("Background canvas element not found.");
+      return;
+    }
   canvas.style.position = "fixed";
   canvas.style.top = 0;
   canvas.style.left = 0;
@@ -214,5 +222,7 @@
         resizeObserver.disconnect(); // Assuming resizeObserver is defined earlier
     }
   });
+
+  }); // end storage.get callback
 
 })();

--- a/01_Projects/JTool - attempt/src/popup/popup.css
+++ b/01_Projects/JTool - attempt/src/popup/popup.css
@@ -736,6 +736,20 @@ body.dark-mode #persistent-timer-display {
   position: relative;
   transition: background var(--transition-duration) ease, border var(--transition-duration) ease;
 }
+
+/* Settings modal layout */
+.setting-group {
+  margin-bottom: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.setting-group.import-export {
+  flex-direction: row;
+  justify-content: space-between;
+  gap: 8px;
+}
 body.dark-mode .modal-content {
     box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.4);
 }

--- a/01_Projects/JTool - attempt/src/popup/popup.html
+++ b/01_Projects/JTool - attempt/src/popup/popup.html
@@ -125,7 +125,44 @@
             <div class="modal-content">
                 <span class="close" data-modal="settings-modal">&times;</span>
                 <h2>Settings</h2>
-                <p>Settings will be available in a future update.</p>
+                <div class="setting-group">
+                    <label for="settings-theme-select">Theme:</label>
+                    <select id="settings-theme-select">
+                        <option value="light">Light</option>
+                        <option value="dark">Dark</option>
+                    </select>
+                </div>
+                <div class="setting-group">
+                    <label><input type="checkbox" id="settings-continuous-timing"> Continuous Timing</label>
+                </div>
+                <div class="setting-group">
+                    <label for="settings-default-session">Default Session Name:</label>
+                    <input type="text" id="settings-default-session">
+                </div>
+                <div class="setting-group">
+                    <label><input type="checkbox" id="settings-show-persistent"> Show Persistent Timer</label>
+                </div>
+                <div class="setting-group">
+                    <label for="settings-default-template">Default Template:</label>
+                    <select id="settings-default-template">
+                        <option value="">None</option>
+                    </select>
+                </div>
+                <div class="setting-group">
+                    <label><input type="checkbox" id="settings-hunter-auto"> Auto-enable Hunter Mode</label>
+                </div>
+                <div class="setting-group">
+                    <label><input type="checkbox" id="settings-show-animation"> Enable Background Animation</label>
+                </div>
+                <div class="setting-group">
+                    <label>Keyboard Shortcuts:</label>
+                    <a href="chrome://extensions/shortcuts" target="_blank">Customize in Browser</a>
+                </div>
+                <div class="setting-group import-export">
+                    <button id="export-settings-btn" class="secondary-btn">Export Settings</button>
+                    <button id="import-settings-btn" class="secondary-btn">Import Settings</button>
+                    <input type="file" id="import-settings-file" accept=".json" style="display:none;">
+                </div>
             </div>
         </div>
         <div id="help-modal" class="modal">


### PR DESCRIPTION
## Summary
- replace placeholder Settings modal with interactive form
- style settings modal groups
- store user preferences in chrome.storage
- apply settings like theme, animation, and timer options on load
- allow exporting and importing settings
- disable background animation when turned off

## Testing
- `npm test`